### PR TITLE
Implement In-Memory Key-Value Store

### DIFF
--- a/deris.go
+++ b/deris.go
@@ -62,6 +62,10 @@ func handleConnection(conn net.Conn, kv map[string]string) {
 				continue
 			}
 			delete(kv, args[1])
+
+		case "EXIT":
+			fmt.Fprintln(conn, "-- Quitting session...")
+			conn.Close()
 		}
 	}
 }


### PR DESCRIPTION
TL;DR: \
This PR refactors `deris.go` from a basic "Hello World" server into an in-memory key-value store, enabling `SET`, `GET`, `DEL`, and `EXIT` commands with integrated error handling.

# Key Additions
- Setting up in-memory database as `map[string]string`
- `GET`, `SET`, `DEL` command parsing and logic
- `EXIT` command to gracefully close client connections

# Changes
- Refactored `handleConnection` to interpret client commands and interact with the key-value store.
- Introduced a dedicated `handleError` function for centralized error reporting to clients and server logs.
- Updated the `main` function to initialize the shared `db` map and pass it to each `handleConnection` goroutine.

# Known Issues
- The in-memory `db` map is **NOT concurrency-safe**; concurrent `SET` or `DEL` operations from multiple clients could lead to race conditions.
- Data stored in the key-value store is **NOT persistent** and will be lost upon server restart.