### PR TITLE
Allow customization of server port & snapshot path via CLI arguments

### DIFF
--- a/cmd/deris/main.go
+++ b/cmd/deris/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/steadyfall/deris"
+)
+
+func main() {
+	var srvPort uint64 = 6969
+	deris.StartServer(srvPort, "snapshot.log")
+}

--- a/cmd/deris/main.go
+++ b/cmd/deris/main.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"github.com/steadyfall/deris"
+	"flag"
 )
 
 func main() {
-	var srvPort uint64 = 6969
+	var srvPort uint64
+	flag.Uint64Var(&srvPort, "port", 6969, "port to listen on")
+	flag.Parse()
+	
 	deris.StartServer(srvPort, "snapshot.log")
 }

--- a/cmd/deris/main.go
+++ b/cmd/deris/main.go
@@ -1,14 +1,49 @@
 package main
 
 import (
-	"github.com/steadyfall/deris"
 	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/steadyfall/deris"
 )
+
+func verifyDirsExist(path string) error {
+	if path == "" {
+		return fmt.Errorf("path is empty")
+	}
+
+	parent := filepath.Dir(filepath.Clean(path))
+
+	info, err := os.Stat(parent)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("directory does not exist: %s", parent)
+		}
+		return fmt.Errorf("error accessing directory: %w", err)
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("path is not a directory: %s", parent)
+	}
+
+	return nil
+}
 
 func main() {
 	var srvPort uint64
 	flag.Uint64Var(&srvPort, "port", 6969, "port to listen on")
+
+	var snapshotFile string
+	flag.StringVar(&snapshotFile, "snapshot", "snapshot.log", "path of snapshot file")
 	flag.Parse()
-	
-	deris.StartServer(srvPort, "snapshot.log")
+
+	// check to ensure that given directory exists
+	if err := verifyDirsExist(snapshotFile); err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid path: %v\n", err)
+		os.Exit(1)
+	}
+
+	deris.StartServer(srvPort, snapshotFile)
 }

--- a/deris.go
+++ b/deris.go
@@ -196,8 +196,3 @@ func StartServer(port uint64, snapshotFile string) {
 		go handleConnection(conn, db, snapshot)
 	}
 }
-
-func main() {
-	var srvPort uint64 = 6969
-	StartServer(srvPort, "snapshot.log")
-}

--- a/deris.go
+++ b/deris.go
@@ -184,7 +184,7 @@ func StartServer(port uint64, snapshotFile string) {
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("server started on port 6969")
+	fmt.Printf("server started on port %d\n", port)
 
 	go handleShutdown(c, lis, snapshotFile, snapshot)
 


### PR DESCRIPTION
This PR introduces a CLI interface allowing customization of the server port and snapshot path via command-line arguments.

### Changes
- Created `cmd/deris/main.go` with:
  - Command-line flags for `port` and `snapshot` file path.
  - Early exit with error if the snapshot file path is invalid.
  - Starts the server via `deris.StartServer` using the provided flags.

- Updated `StartServer` in `deris.go` to:
  - Print the actual listening port instead of a hardcoded value.
  - Removed the old `main` function since `main.go` now handles startup.

### How to Test
- Build CLI binary with: `go build -o deris-cli cmd/deris/main.go`. 
- Run `deris` with default or custom snapshot path pointing to existing directories - the server should start and print the correct port.
- Run with a snapshot path whose parent directory does not exist - the program should print an error and exit immediately.